### PR TITLE
Make order total refresh in Safari

### DIFF
--- a/src/app/order/order.component.html
+++ b/src/app/order/order.component.html
@@ -12,7 +12,7 @@
     <md-list>
       <md-list-item>
         <span mdLine>Total</span>
-        <span mdLine class="order-total">{{ getOrderTotal() | price }}</span>
+        <span #orderTotalElement mdLine class="order-total">{{ orderTotal | price }}</span>
       </md-list-item>
     </md-list>
   </md-card-content>


### PR DESCRIPTION
This is a pretty nasty hack where the total element is hidden and then displayed in Safari to force a redraw. I don’t know the actual underlying cause.
Fixes #39